### PR TITLE
Removed IIFE-loop in scraper.ts

### DIFF
--- a/services/scraper.ts
+++ b/services/scraper.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { load } from 'cheerio';
 import iconv from 'iconv-lite';
-import { urls as importedUrls } from './urls';
 
 interface DomainRules {
   [key: string]: string[];
@@ -109,17 +108,3 @@ export const scrapeURL = async (url: string): Promise<string> => {
     throw error;
   }
 };
-
-// Skrapa innehåll från alla URL:er i listan
-const urls = importedUrls;
-
-(async () => {
-  for (const url of urls) {
-    try {
-      const content = await scrapeURL(url);
-      console.log(`Content from ${url}:`, content);
-    } catch (error) {
-      console.error(`Error scraping ${url}:`, error);
-    }
-  }
-})();


### PR DESCRIPTION
Currently, scraper.ts contains an immediately-invoked function expression (IIFE) that loops over urls for a quick test-run of the scrapeURL function. This is no longer necessary since we primarily invoke scrapeURL in generate-answer.ts (or other files) to handle the scraping logic. Removing the IIFE will simplify the file and prevent any confusion about duplicate loops.